### PR TITLE
Update check_rate_limit function in AWS Lambda to use seconds instead…

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -271,8 +271,8 @@ def check_rate_limit(account_id: str) -> Tuple[bool, Optional[str]]:
         
         # Check current invocation count
         rl_table = dynamodb.Table('RL_AWS')
-        current_time = int(time.time() * 1000)  # Current time in milliseconds
-        ttl_time = current_time + (60 * 1000)  # 1 minute from now
+        current_time = int(time.time())  # Current time in seconds
+        ttl_time = current_time + 60  # 1 minute from now
         
         # Try to get existing record
         try:


### PR DESCRIPTION
… of milliseconds for time calculations. Adjusted TTL calculation to reflect the change, ensuring accurate rate limit enforcement.